### PR TITLE
Add typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -119,7 +119,9 @@ declare module "awfltst" {
     subtest(name: string, options: AwfltstOptions, fn: Function) : Promise<void>;
 
     throws(test: Function|Promise<any>, expected?: RegExp|Function, name?: string): Promise<void>
-      notThrows(test: Function|Promise<any>, expected?: RegExp|Function, name?: string): Promise<void>
+    throws(test: Function|Promise<any>, name?: string): Promise<void>
+    notThrows(test: Function|Promise<any>, expected?: RegExp|Function, name?: string): Promise<void>
+    notThrows(test: Function|Promise<any>, name?: string): Promise<void>
   }
 
   export default function(fn: TestFunction) : void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,149 @@
+declare module "awfltst" {
+  import * as AWFLTST from "awfltst"
+
+  // This should ideally be retrieved from the @types/node module, but
+  // since this is the only requirement of that module, adding a
+  // dependency on @types/node to the project seems like a waste.
+  //
+  // The only downside of doing it this way is that it won't
+  // automatically get updated, in case the InspectOptions gets
+  // additional options.
+  export interface InspectOptions {
+    getters?: 'get' | 'set' | boolean;
+    showHidden?: boolean;
+
+    depth?: number | null;
+    colors?: boolean;
+    customInspect?: boolean;
+    showProxy?: boolean;
+    maxArrayLength?: number | null;
+    breakLength?: number;
+    compact?: boolean | number;
+    sorted?: boolean | ((a: string, b: string) => number);
+  }
+
+  export interface AwfltstOptions {
+    skip?: boolean;
+    only?: boolean;
+    console?: boolean;
+    inspect?: InspectOptions;
+  }
+
+  export interface ComparatorOptions {
+    operator?: string;
+    expected?: string;
+    actual?: string;
+    diffable?: boolean;
+    at?: string;
+  }
+
+  export type TestFunction = (this: Test) => void;
+
+  class Test {
+    stdout: string
+    stderr: string
+
+    plan(expected: number, name?: string): Test;
+
+    compare(comparator: Function, actual: any, expected: any, options?: ComparatorOptions): Test;
+    compareWith(comparator: Function, actual: any, expected: any, options?: ComparatorOptions): Test;
+
+    chain(name?: string) : Test;
+    unchain(): Test;
+
+    fail(name?: string): Test;
+    pass(name?: string): Test;
+
+    error(error: any, name?: string): Test;
+    ok(actual: any, name?: string): Test;
+    true(actual: any, name?: string): Test;
+
+    not(actual: any, name?: string): Test;
+    notOk(actual: any, name?: string): Test;
+    notok(actual: any, name?: string): Test;
+    false(actual: any, name?: string): Test;
+
+    eq(actual: any, expected: any, name?: string): Test;
+    deepStrictEquals(actual: any, expected: any, name?: string): Test;
+    deepStrictEqual(actual: any, expected: any, name?: string): Test;
+    deepEquals(actual: any, expected: any, name?: string): Test;
+    deepEqual(actual: any, expected: any, name?: string): Test;
+    equals(actual: any, expected: any, name?: string): Test;
+    equal(actual: any, expected: any, name?: string): Test;
+    is(actual: any, expected: any, name?: string): Test;
+
+    ne(actual: any, expected: any, name?: string): Test;
+    notDeepStrictEquals(actual: any, expected: any, name?: string): Test;
+    notDeepStrictEqual(actual: any, expected: any, name?: string): Test;
+    notDeepEquals(actual: any, expected: any, name?: string): Test;
+    notDeepEqual(actual: any, expected: any, name?: string): Test;
+    notEquals(actual: any, expected: any, name?: string): Test;
+    notEqual(actual: any, expected: any, name?: string): Test;
+    isNot(actual: any, expected: any, name?: string): Test;
+    neq(actual: any, expected: any, name?: string): Test;
+
+    gt(actual: any, expected: any, name?: string): Test;
+    greaterThan(actual: any, expected: any, name?: string): Test;
+    greater(actual: any, expected: any, name?: string): Test;
+
+    gte(actual: any, expected: any, name?: string): Test;
+    greaterThanOrEquals(actual: any, expected: any, name?: string): Test;
+    greaterThanOrEqual(actual: any, expected: any, name?: string): Test;
+    greaterOrEquals(actual: any, expected: any, name?: string): Test;
+    greaterOrEqual(actual: any, expected: any, name?: string): Test;
+    ge(actual: any, expected: any, name?: string): Test;
+
+    lte(actual: any, expected: any, name?: string): Test;
+    lessThanOrEquals(actual: any, expected: any, name?: string): Test;
+    lessThanOrEqual(actual: any, expected: any, name?: string): Test;
+    lessOrEquals(actual: any, expected: any, name?: string): Test;
+    lessOrEqual(actual: any, expected: any, name?: string): Test;
+    le(actual: any, expected: any, name?: string): Test;
+
+    lt(actual: any, expected: any, name?: string): Test;
+    lessThan(actual: any, expected: any, name?: string): Test;
+    lessThan(actual: any, expected: any, name?: string): Test;
+
+    between(actual: any, min: any, max: any, name?: string): Test;
+    notBetween(actual: any, min: any, max: any, name?: string): Test;
+
+    approx(actual: number, expected: number, variance: number, name?: string): Test;
+    approximately(actual: number, expected: number, variance: number, name?: string): Test;
+
+    contains(actual: string|Array<any>, expected: string|Array<any>, name?: string): Test;
+    in(actual: string|Array<any>, expected: string|Array<any>, name?: string): Test;
+    notIn(actual: string|Array<any>, expected: string|Array<any>, name?: string): Test;
+    match(actual: string, expected: RegExp, name?: string): Test;
+    notMatch(actual: string, expected: RegExp, name?: string): Test;
+
+    type(actual: any, expected: Function|String, name?: string): Test
+    instanceOf(actual: any, expected: Function|String, name?: string): Test
+    instanceof(actual: any, expected: Function|String, name?: string): Test
+    instance(actual: any, expected: Function|String, name?: string): Test
+    typeOf(actual: any, expected: Function|String, name?: string): Test
+    typeof(actual: any, expected: Function|String, name?: string): Test
+
+    test(fn: TestFunction) : Promise<void>;
+    test(name: string, fn: TestFunction) : Promise<void>;
+    test(options: AwfltstOptions, fn: TestFunction) : Promise<void>;
+    test(name: string, options: AwfltstOptions, fn: TestFunction) : Promise<void>;
+
+    subTest(fn: TestFunction) : Promise<void>;
+    subTest(name: string, fn: TestFunction) : Promise<void>;
+    subTest(options: AwfltstOptions, fn: TestFunction) : Promise<void>;
+    subTest(name: string, options: AwfltstOptions, fn: TestFunction) : Promise<void>;
+
+    subtest(fn: Function) : Promise<void>;
+    subtest(name: string, fn: Function) : Promise<void>;
+    subtest(options: AwfltstOptions, fn: Function) : Promise<void>;
+    subtest(name: string, options: AwfltstOptions, fn: Function) : Promise<void>;
+
+    throws(test: Function|Promise<any>, expected?: RegExp|Function, name?: string): Promise<void>
+      notThrows(test: Function|Promise<any>, expected?: RegExp|Function, name?: string): Promise<void>
+  }
+
+  export default function(fn: TestFunction) : void;
+  export default function(name: string, fn: TestFunction) : void;
+  export default function(options: AwfltstOptions, fn: TestFunction) : void;
+  export default function(name: string, options: AwfltstOptions, fn: TestFunction) : void;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,26 +1,6 @@
 declare module "awfltst" {
   import * as AWFLTST from "awfltst"
-
-  // This should ideally be retrieved from the @types/node module, but
-  // since this is the only requirement of that module, adding a
-  // dependency on @types/node to the project seems like a waste.
-  //
-  // The only downside of doing it this way is that it won't
-  // automatically get updated, in case the InspectOptions gets
-  // additional options.
-  export interface InspectOptions {
-    getters?: 'get' | 'set' | boolean;
-    showHidden?: boolean;
-
-    depth?: number | null;
-    colors?: boolean;
-    customInspect?: boolean;
-    showProxy?: boolean;
-    maxArrayLength?: number | null;
-    breakLength?: number;
-    compact?: boolean | number;
-    sorted?: boolean | ((a: string, b: string) => number);
-  }
+  import {InspectOptions} from 'util';
 
   export interface AwfltstOptions {
     skip?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,6 @@ declare module "awfltst" {
 
   type ArrayLike<T> =
     T extends string ? string | Array<string> :
-    T extends (infer U)[] ? Array<U> :
     Array<T>;
 
   type NonArrayLike<T> =
@@ -100,11 +99,11 @@ declare module "awfltst" {
     approx(actual: number, expected: number, variance: number, name?: string): Test;
     approximately(actual: number, expected: number, variance: number, name?: string): Test;
 
-    contains<T>(actual: ArrayLike<T>, expected: NonArrayLike<T>, name?: string): Test;
-    notContains<T>(actual: ArrayLike<T>, expected: NonArrayLike<T>, name?: string): Test;
+    contains<T>(actual: ArrayLike<T>, expected: T, name?: string): Test;
+    notContains<T>(actual: ArrayLike<T>, expected: T, name?: string): Test;
 
-    in<T>(actual: NonArrayLike<T>, expected: ArrayLike<T>, name?: string): Test;
-    notIn<T>(actual: NonArrayLike<T>, expected: ArrayLike<T>, name?: string): Test;
+    in<T>(actual: T, expected: ArrayLike<T>, name?: string): Test;
+    notIn<T>(actual: T, expected: ArrayLike<T>, name?: string): Test;
 
     match(actual: string, expected: RegExp, name?: string): Test;
     notMatch(actual: string, expected: RegExp, name?: string): Test;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,11 +6,6 @@ declare module "awfltst" {
     T extends string ? string | Array<string> :
     Array<T>;
 
-  type NonArrayLike<T> =
-    T extends string ? string :
-    T extends (infer U)[] ? U :
-    T;
-
   export interface AwfltstOptions {
     skip?: boolean;
     only?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,15 +20,15 @@ declare module "awfltst" {
   export type TestFunction = (this: Test, t: Test) => void;
 
   class Test {
-    stdout: string
-    stderr: string
+    stdout: string;
+    stderr: string;
 
     plan(expected: number, name?: string): Test;
 
     compare(comparator: Function, actual: any, expected: any, options?: ComparatorOptions): Test;
     compareWith(comparator: Function, actual: any, expected: any, options?: ComparatorOptions): Test;
 
-    chain(name?: string) : Test;
+    chain(name?: string): Test;
     unchain(): Test;
 
     fail(name?: string): Test;
@@ -103,12 +103,12 @@ declare module "awfltst" {
     match(actual: string, expected: RegExp, name?: string): Test;
     notMatch(actual: string, expected: RegExp, name?: string): Test;
 
-    type(actual: any, expected: Function|String, name?: string): Test
-    instanceOf(actual: any, expected: Function|String, name?: string): Test
-    instanceof(actual: any, expected: Function|String, name?: string): Test
-    instance(actual: any, expected: Function|String, name?: string): Test
-    typeOf(actual: any, expected: Function|String, name?: string): Test
-    typeof(actual: any, expected: Function|String, name?: string): Test
+    type(actual: any, expected: Function|String, name?: string): Test;
+    instanceOf(actual: any, expected: Function|String, name?: string): Test;
+    instanceof(actual: any, expected: Function|String, name?: string): Test;
+    instance(actual: any, expected: Function|String, name?: string): Test;
+    typeOf(actual: any, expected: Function|String, name?: string): Test;
+    typeof(actual: any, expected: Function|String, name?: string): Test;
 
     test(fn: TestFunction): Promise<void>;
     test(name: string, fn: TestFunction): Promise<void>;
@@ -146,10 +146,10 @@ declare module "awfltst" {
     subtest(fn: TestFunction, name: string, options: AwfltstOptions): Promise<void>;
     subtest(fn: TestFunction, options: AwfltstOptions, name: string): Promise<void>;
 
-    throws(test: Function|Promise<any>, expected?: RegExp|Function, name?: string): Promise<void>
-    throws(test: Function|Promise<any>, name?: string): Promise<void>
-    notThrows(test: Function|Promise<any>, expected?: RegExp|Function, name?: string): Promise<void>
-    notThrows(test: Function|Promise<any>, name?: string): Promise<void>
+    throws(test: Function|Promise<any>, expected?: RegExp|Function, name?: string): Promise<void>;
+    throws(test: Function|Promise<any>, name?: string): Promise<void>;
+    notThrows(test: Function|Promise<any>, expected?: RegExp|Function, name?: string): Promise<void>;
+    notThrows(test: Function|Promise<any>, name?: string): Promise<void>;
   }
 
   export default function(fn: TestFunction): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,16 @@ declare module "awfltst" {
   import * as AWFLTST from "awfltst"
   import {InspectOptions} from 'util';
 
+  type ArrayLike<T> =
+    T extends string ? string | Array<string> :
+    T extends (infer U)[] ? Array<U> :
+    Array<T>;
+
+  type NonArrayLike<T> =
+    T extends string ? string :
+    T extends (infer U)[] ? U :
+    T;
+
   export interface AwfltstOptions {
     skip?: boolean;
     only?: boolean;
@@ -90,11 +100,11 @@ declare module "awfltst" {
     approx(actual: number, expected: number, variance: number, name?: string): Test;
     approximately(actual: number, expected: number, variance: number, name?: string): Test;
 
-    contains<T>(actual: T[]|string, expected: T, name?: string): Test;
-    notContains<T>(actual: T[]|string, expected: T, name?: string): Test;
+    contains<T>(actual: ArrayLike<T>, expected: NonArrayLike<T>, name?: string): Test;
+    notContains<T>(actual: ArrayLike<T>, expected: NonArrayLike<T>, name?: string): Test;
 
-    in<T>(actual: T, expected: T[]|string, name?: string): Test;
-    notIn<T>(actual: T, expected: T[]|string, name?: string): Test;
+    in<T>(actual: NonArrayLike<T>, expected: ArrayLike<T>, name?: string): Test;
+    notIn<T>(actual: NonArrayLike<T>, expected: ArrayLike<T>, name?: string): Test;
 
     match(actual: string, expected: RegExp, name?: string): Test;
     notMatch(actual: string, expected: RegExp, name?: string): Test;

--- a/index.d.ts
+++ b/index.d.ts
@@ -110,20 +110,41 @@ declare module "awfltst" {
     typeOf(actual: any, expected: Function|String, name?: string): Test
     typeof(actual: any, expected: Function|String, name?: string): Test
 
-    test(fn: TestFunction) : Promise<void>;
-    test(name: string, fn: TestFunction) : Promise<void>;
-    test(options: AwfltstOptions, fn: TestFunction) : Promise<void>;
-    test(name: string, options: AwfltstOptions, fn: TestFunction) : Promise<void>;
+    test(fn: TestFunction): Promise<void>;
+    test(name: string, fn: TestFunction): Promise<void>;
+    test(fn: TestFunction, name: string): Promise<void>;
+    test(options: AwfltstOptions, fn: TestFunction): Promise<void>;
+    test(fn: TestFunction, options: AwfltstOptions): Promise<void>;
+    test(name: string, options: AwfltstOptions, fn: TestFunction): Promise<void>;
+    test(name: string, fn: TestFunction, options: AwfltstOptions): Promise<void>;
+    test(options: AwfltstOptions, name: string, fn: TestFunction): Promise<void>;
+    test(options: AwfltstOptions, fn: TestFunction, name: string): Promise<void>;
+    test(fn: TestFunction, name: string, options: AwfltstOptions): Promise<void>;
+    test(fn: TestFunction, options: AwfltstOptions, name: string): Promise<void>;
 
-    subTest(fn: TestFunction) : Promise<void>;
-    subTest(name: string, fn: TestFunction) : Promise<void>;
-    subTest(options: AwfltstOptions, fn: TestFunction) : Promise<void>;
-    subTest(name: string, options: AwfltstOptions, fn: TestFunction) : Promise<void>;
+    subTest(fn: TestFunction): Promise<void>;
+    subTest(name: string, fn: TestFunction): Promise<void>;
+    subTest(fn: TestFunction, name: string): Promise<void>;
+    subTest(options: AwfltstOptions, fn: TestFunction): Promise<void>;
+    subTest(fn: TestFunction, options: AwfltstOptions): Promise<void>;
+    subTest(name: string, options: AwfltstOptions, fn: TestFunction): Promise<void>;
+    subTest(name: string, fn: TestFunction, options: AwfltstOptions): Promise<void>;
+    subTest(options: AwfltstOptions, name: string, fn: TestFunction): Promise<void>;
+    subTest(options: AwfltstOptions, fn: TestFunction, name: string): Promise<void>;
+    subTest(fn: TestFunction, name: string, options: AwfltstOptions): Promise<void>;
+    subTest(fn: TestFunction, options: AwfltstOptions, name: string): Promise<void>;
 
-    subtest(fn: Function) : Promise<void>;
-    subtest(name: string, fn: Function) : Promise<void>;
-    subtest(options: AwfltstOptions, fn: Function) : Promise<void>;
-    subtest(name: string, options: AwfltstOptions, fn: Function) : Promise<void>;
+    subtest(fn: TestFunction): Promise<void>;
+    subtest(name: string, fn: TestFunction): Promise<void>;
+    subtest(fn: TestFunction, name: string): Promise<void>;
+    subtest(options: AwfltstOptions, fn: TestFunction): Promise<void>;
+    subtest(fn: TestFunction, options: AwfltstOptions): Promise<void>;
+    subtest(name: string, options: AwfltstOptions, fn: TestFunction): Promise<void>;
+    subtest(name: string, fn: TestFunction, options: AwfltstOptions): Promise<void>;
+    subtest(options: AwfltstOptions, name: string, fn: TestFunction): Promise<void>;
+    subtest(options: AwfltstOptions, fn: TestFunction, name: string): Promise<void>;
+    subtest(fn: TestFunction, name: string, options: AwfltstOptions): Promise<void>;
+    subtest(fn: TestFunction, options: AwfltstOptions, name: string): Promise<void>;
 
     throws(test: Function|Promise<any>, expected?: RegExp|Function, name?: string): Promise<void>
     throws(test: Function|Promise<any>, name?: string): Promise<void>
@@ -131,8 +152,15 @@ declare module "awfltst" {
     notThrows(test: Function|Promise<any>, name?: string): Promise<void>
   }
 
-  export default function(fn: TestFunction) : void;
-  export default function(name: string, fn: TestFunction) : void;
-  export default function(options: AwfltstOptions, fn: TestFunction) : void;
-  export default function(name: string, options: AwfltstOptions, fn: TestFunction) : void;
+  export default function(fn: TestFunction): void;
+  export default function(name: string, fn: TestFunction): void;
+  export default function(fn: TestFunction, name: string): void;
+  export default function(options: AwfltstOptions, fn: TestFunction): void;
+  export default function(fn: TestFunction, options: AwfltstOptions): void;
+  export default function(name: string, options: AwfltstOptions, fn: TestFunction): void;
+  export default function(name: string, fn: TestFunction, options: AwfltstOptions): void;
+  export default function(options: AwfltstOptions, name: string, fn: TestFunction): void;
+  export default function(options: AwfltstOptions, fn: TestFunction, name: string): void;
+  export default function(fn: TestFunction, name: string, options: AwfltstOptions): void;
+  export default function(fn: TestFunction, options: AwfltstOptions, name: string): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ declare module "awfltst" {
     at?: string;
   }
 
-  export type TestFunction = (this: Test) => void;
+  export type TestFunction = (this: Test, t: Test) => void;
 
   class Test {
     stdout: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,24 +47,24 @@ declare module "awfltst" {
     notok(actual: any, name?: string): Test;
     false(actual: any, name?: string): Test;
 
-    eq(actual: any, expected: any, name?: string): Test;
-    deepStrictEquals(actual: any, expected: any, name?: string): Test;
-    deepStrictEqual(actual: any, expected: any, name?: string): Test;
-    deepEquals(actual: any, expected: any, name?: string): Test;
-    deepEqual(actual: any, expected: any, name?: string): Test;
-    equals(actual: any, expected: any, name?: string): Test;
-    equal(actual: any, expected: any, name?: string): Test;
-    is(actual: any, expected: any, name?: string): Test;
+    eq<T>(actual: T, expected: T, name?: string): Test;
+    deepStrictEquals<T>(actual: T, expected: T, name?: string): Test;
+    deepStrictEqual<T>(actual: T, expected: T, name?: string): Test;
+    deepEquals<T>(actual: T, expected: T, name?: string): Test;
+    deepEqual<T>(actual: T, expected: T, name?: string): Test;
+    equals<T>(actual: T, expected: T, name?: string): Test;
+    equal<T>(actual: T, expected: T, name?: string): Test;
+    is<T>(actual: T, expected: T, name?: string): Test;
 
-    ne(actual: any, expected: any, name?: string): Test;
-    notDeepStrictEquals(actual: any, expected: any, name?: string): Test;
-    notDeepStrictEqual(actual: any, expected: any, name?: string): Test;
-    notDeepEquals(actual: any, expected: any, name?: string): Test;
-    notDeepEqual(actual: any, expected: any, name?: string): Test;
-    notEquals(actual: any, expected: any, name?: string): Test;
-    notEqual(actual: any, expected: any, name?: string): Test;
-    isNot(actual: any, expected: any, name?: string): Test;
-    neq(actual: any, expected: any, name?: string): Test;
+    ne<T>(actual: T, expected: T, name?: string): Test;
+    notDeepStrictEquals<T>(actual: T, expected: T, name?: string): Test;
+    notDeepStrictEqual<T>(actual: T, expected: T, name?: string): Test;
+    notDeepEquals<T>(actual: T, expected: T, name?: string): Test;
+    notDeepEqual<T>(actual: T, expected: T, name?: string): Test;
+    notEquals<T>(actual: T, expected: T, name?: string): Test;
+    notEqual<T>(actual: T, expected: T, name?: string): Test;
+    isNot<T>(actual: T, expected: T, name?: string): Test;
+    neq<T>(actual: T, expected: T, name?: string): Test;
 
     gt(actual: any, expected: any, name?: string): Test;
     greaterThan(actual: any, expected: any, name?: string): Test;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,10 +2,6 @@ declare module "awfltst" {
   import * as AWFLTST from "awfltst"
   import {InspectOptions} from 'util';
 
-  type ArrayLike<T> =
-    T extends string ? string | Array<string> :
-    Array<T>;
-
   export interface AwfltstOptions {
     skip?: boolean;
     only?: boolean;
@@ -94,11 +90,15 @@ declare module "awfltst" {
     approx(actual: number, expected: number, variance: number, name?: string): Test;
     approximately(actual: number, expected: number, variance: number, name?: string): Test;
 
-    contains<T>(actual: ArrayLike<T>, expected: T, name?: string): Test;
-    notContains<T>(actual: ArrayLike<T>, expected: T, name?: string): Test;
+    contains<T>(actual: Array<T>, expected: T, name?: string): Test;
+    contains(actual: string, expected: string, name?: string): Test;
+    notContains<T>(actual: Array<T>, expected: T, name?: string): Test;
+    notContains(actual: string, expected: string, name?: string): Test;
 
-    in<T>(actual: T, expected: ArrayLike<T>, name?: string): Test;
-    notIn<T>(actual: T, expected: ArrayLike<T>, name?: string): Test;
+    in<T>(actual: T, expected: Array<T>, name?: string): Test;
+    in(actual: string, expected: string, name?: string): Test;
+    notIn<T>(actual: T, expected: Array<T>, name?: string): Test;
+    notIn(actual: string, expected: string, name?: string): Test;
 
     match(actual: string, expected: RegExp, name?: string): Test;
     notMatch(actual: string, expected: RegExp, name?: string): Test;

--- a/index.d.ts
+++ b/index.d.ts
@@ -90,9 +90,12 @@ declare module "awfltst" {
     approx(actual: number, expected: number, variance: number, name?: string): Test;
     approximately(actual: number, expected: number, variance: number, name?: string): Test;
 
-    contains(actual: string|Array<any>, expected: string|Array<any>, name?: string): Test;
-    in(actual: string|Array<any>, expected: string|Array<any>, name?: string): Test;
-    notIn(actual: string|Array<any>, expected: string|Array<any>, name?: string): Test;
+    contains<T>(actual: T[]|string, expected: T, name?: string): Test;
+    notContains<T>(actual: T[]|string, expected: T, name?: string): Test;
+
+    in<T>(actual: T, expected: T[]|string, name?: string): Test;
+    notIn<T>(actual: T, expected: T[]|string, name?: string): Test;
+
     match(actual: string, expected: RegExp, name?: string): Test;
     notMatch(actual: string, expected: RegExp, name?: string): Test;
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.2",
   "description": "async test library",
   "main": "lib",
+  "types": "index.d.ts",
   "bin": {
     "awfltst": "bin.js"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "./bin.js test/*.js"
   },
   "dependencies": {
+    "@types/node": "^11.13.8",
     "diff": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This will allow typescript users of this package to get full type
information as well as autocompletion should they use such a tool.

There are no actual code changes with this commit and should have no
impact on the tests themselves.

Note: Ideally, `@types/node` should have been a dependency in this
package as the `InspectOptions` type is defined within this package.
However, as that was the only type that was used, I decided to copy it
from the type package instead. The downside of this is that if
`InspectOptions` is updated, the index.d.ts won't automatically be
updated.

Another note: At the bottom of the index.d.ts, it exposes four different
versions of the test function. However, these are only a few of the
different versions that can be used as the arguments can be sent to it
in any order.

## Test the types

A simple way to test that this works is:

```bash
# first clone the repo with the changes
git clone git@github.com:reewr/awfltst.git awfltst-reewr
cd awfltst-reewr
git checkout ts-typings

# now create a test folder for new npm project
cd ..
mkdir test-ts-typings
cd test-ts-typings
npm init

# install typescript for testing
npm install --save typescript
npm install ../awfltst-reewr # this creates a symlink to the repo
./node_modules/.bin/tsc --init

# Edit the newly generated tsconfig.json file and update `target` to `es6`
# as it uses async functions (async functions are a part of TypeScript, 
# but it requires ES6 to function due to needing Promises)
```
Add a new file:
```typescript
// index.ts
import test from 'awfltst';

test('something', async function() {
    this.eq(5, 1);
    this.eq(1, 1, 'message', 'notAnArgument'); // this line should have an error
    this.approx('string', 5, 1); // and this, because only numbers are allowed
});
```

You should now be able to run `tsc` and see the following errors due to incorrect types:

```text
index.ts:5:5 - error TS2554: Expected 2-3 arguments, but got 4.

5     this.eq(1, 1, 'message', 'notAnArgument'); // this line should have an error
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

index.ts:6:17 - error TS2345: Argument of type '"string"' is not assignable to parameter of type 'number'.

6     this.approx('string', 5, 1);  // and this, because only numbers are allowed
                  ~~~~~~~~


Found 2 errors.
```